### PR TITLE
Feature: Add basic Psalm plugin for ComposeSimple

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -6,10 +6,15 @@
     errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
-        <directory name="src" />
+        <directory name="src"/>
+        <directory name="tests"/>
         <ignoreFiles>
-            <directory name="vendor" />
-            <directory name="spec" />
+            <directory name="vendor"/>
+            <directory name="spec"/>
         </ignoreFiles>
     </projectFiles>
+
+    <plugins>
+        <pluginClass class="loophp\fpt\Psalm\Plugin" />
+    </plugins>
 </psalm>

--- a/src/ComposeSimple.php
+++ b/src/ComposeSimple.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\fpt;
+
+use Closure;
+
+// phpcs:disable Generic.Files.LineLength.TooLong
+
+/**
+ * @immutable
+ */
+final class ComposeSimple
+{
+    /**
+     * @pure
+     */
+    public static function of(): Closure
+    {
+        return
+            static function (callable ...$fs): Closure {
+                // Identity
+                $initial = static fn ($v) => $v;
+
+                foreach ($fs as $f) {
+                    $initial = ComposeSimple::of1()($initial)($f);
+                }
+
+                return $initial;
+            };
+    }
+
+    private static function of1(): Closure
+    {
+        return
+            static fn (callable $f): Closure => static fn (callable $g): Closure => static fn (...$x): mixed => $f($g(...$x));
+    }
+}

--- a/src/Psalm/EventHandler/ComposeSimple/AfterExpressionAnalysisProvider.php
+++ b/src/Psalm/EventHandler/ComposeSimple/AfterExpressionAnalysisProvider.php
@@ -9,13 +9,59 @@ declare(strict_types=1);
 
 namespace loophp\fpt\Psalm\EventHandler\ComposeSimple;
 
-use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
-use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
+use PhpParser\Node;
+use PhpParser\Node\FunctionLike;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use Psalm\Internal\Analyzer\MethodAnalyzer;
+use Psalm\Plugin\EventHandler\AfterFunctionLikeAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterFunctionLikeAnalysisEvent;
 
-final class AfterExpressionAnalysisProvider implements AfterExpressionAnalysisInterface
+final class AfterExpressionAnalysisProvider implements AfterFunctionLikeAnalysisInterface
 {
-    public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool
-    {
+
+    public static function afterStatementAnalysis(AfterFunctionLikeAnalysisEvent $event): ?bool {
+        $stmtSource = $event->getStatementsSource();
+
+        if (false === ($stmtSource instanceof MethodAnalyzer)) {
+            return false;
+        }
+
+        if ('of' !== $stmtSource->getMethodName()) {
+            return false;
+        }
+
+        $ast = $event->getStmt();
+
+        if (false === ($ast instanceof FunctionLike)) {
+            return false;
+        }
+
+        $closure = self::getNextClosure($ast);
+
+        // This is the $fs param of ComposeSimple::of()(callable ...$fs);
+        // ----------------------------------------------------------^
+        $param = current($closure->getParams());
+
+        // Questions
+        // 1. What to do from there?
+
         return true;
+    }
+
+    private static function getNextClosure($ast): Node\Expr\Closure
+    {
+        $traverser = new NodeTraverser();
+
+        $traverser->addVisitor(new class extends NodeVisitorAbstract {
+            public function enterNode(Node $node): ?Node\Stmt\Return_ {
+                return $node instanceof Node\Stmt\Return_ ? $node : null;
+            }
+        });
+
+        /** @var array<int, \PhpParser\Node\Stmt\Return_> $returnStatement */
+        $returnStatement = $traverser->traverse($ast->getStmts());
+
+        return current($returnStatement)->expr;
     }
 }

--- a/src/Psalm/EventHandler/ComposeSimple/AfterExpressionAnalysisProvider.php
+++ b/src/Psalm/EventHandler/ComposeSimple/AfterExpressionAnalysisProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\fpt\Psalm\EventHandler\ComposeSimple;
+
+use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
+
+final class AfterExpressionAnalysisProvider implements AfterExpressionAnalysisInterface
+{
+    public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool
+    {
+        return true;
+    }
+}

--- a/src/Psalm/Plugin.php
+++ b/src/Psalm/Plugin.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\fpt\Psalm;
+
+use loophp\fpt\Psalm\EventHandler\ComposeSimple\AfterExpressionAnalysisProvider;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Plugin\PluginEntryPointInterface;
+use Psalm\Plugin\RegistrationInterface;
+use SimpleXMLElement;
+
+use function str_replace;
+
+final class Plugin implements PluginEntryPointInterface
+{
+    public function __invoke(RegistrationInterface $registration, ?SimpleXMLElement $config = null): void
+    {
+        foreach ($this->getHooks() as $hook) {
+            /** @psalm-suppress UnresolvableInclude */
+            $file = __DIR__ . '/' . str_replace([__NAMESPACE__, '\\'], ['', '/'], $hook) . '.php';
+
+            require_once $file;
+
+            $registration->registerHooksFromClass($hook);
+        }
+    }
+
+    /**
+     * @return iterable<class-string<MethodReturnTypeProviderInterface>>
+     */
+    private function getHooks(): iterable
+    {
+        yield AfterExpressionAnalysisProvider::class;
+    }
+}

--- a/tests/compose-simple.php
+++ b/tests/compose-simple.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use loophp\fpt\ComposeSimple;
+
+include __DIR__ . '/../vendor/autoload.php';
+
+$stringToInt = static fn (string $n): int => (int) $n;
+$intToBool = static fn (int $n): bool => 0 === $n % 2;
+$boolToInt = static fn (bool $n): int => (int) $n;
+$intToString = static fn (int $n): string => 0 === $n ? 'zero' : 'one';
+
+function compose_check_string(string $data): void
+{
+    var_dump($data);
+}
+
+function compose_check_int(int $data): void
+{
+    var_dump($data);
+}
+
+compose_check_string(
+    ComposeSimple::of()($intToString, $boolToInt, $intToBool, $stringToInt)('50') // 'one'
+);
+
+compose_check_int(
+    ComposeSimple::of()($boolToInt, $intToBool, $stringToInt)('51') // 0
+);


### PR DESCRIPTION
The purpose of this PR is:

* Learn Psalm/PHPstan plugin authoring
* Provide a better way to type functional operations like `ComposeSimple` (step 1) and `Compose` (step 2)

In order to find a way to do that in a simple way, I created a `ComposeSimple` class that does the same as `Compose` but without using `Fold`.

I will first try to get the plugin work with `ComposeSimple` and then make it work with `Compose` and `Fold`.

I first tried to do this using `MethodReturnTypeProvider` but according to @orklah, I should be using `AfterFunctionLikeAnalysisInterface` or `AfterExpressionAnalysisInterface`.

Related to https://github.com/vimeo/psalm/issues/1999
